### PR TITLE
BTA-13953: Migrate GHA Runner from MacOS-12 to Windows-2019

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,18 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: windows-2019
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Install Nuget
-        run: | 
-          rm -rf '/usr/local/share/man/man1'
-          rm -rf '/usr/local/share/man/man5'
-          brew install nuget
-    
+        uses: nuget/setup-nuget@v2
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
       - name: Restore NuGet Packages
         run: nuget restore -SolutionDirectory ../..
         working-directory: src/TransferZero.Sdk
@@ -26,7 +26,7 @@ jobs:
       - name: Build and Pack
         run: |
           msbuild /property:Configuration=Release
-          nuget pack TransferZero.Sdk.csproj -properties Configuration=Release -MSBuildPath /usr/local/lib/mono/msbuild/Current/bin/
+          nuget pack TransferZero.Sdk.csproj -properties Configuration=Release 
         working-directory: src/TransferZero.Sdk
 
       - name: Publish to NuGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Nuget
         uses: nuget/setup-nuget@v2
 
-      - name: Add msbuild to PATH
+      - name: Install msbuild and add to PATH
         uses: microsoft/setup-msbuild@v2
 
       - name: Restore NuGet Packages


### PR DESCRIPTION
BTA-13953: Migrate GHA Runner from MacOS-12 to Windows-2019

Changes:
---------
* Migrated GitHub Action Runner OS from MacOS-12 to Windows-2019 due to missing microsoft build dll. This library is required in the nuget release of transferzero dotnet sdk.