### PR TITLE
BTA-15646 Update target framework version

### DIFF
--- a/src/TransferZero.Sdk/TransferZero.Sdk.csproj
+++ b/src/TransferZero.Sdk/TransferZero.Sdk.csproj
@@ -9,7 +9,7 @@ OpenAPI spec version: 1.0
 -->
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    
+
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{94c1fc93-2648-4ab0-90fe-10f7555259ef}</ProjectGuid>
@@ -17,7 +17,7 @@ OpenAPI spec version: 1.0
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TransferZero.Sdk</RootNamespace>
     <AssemblyName>TransferZero.Sdk</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -75,4 +75,3 @@ OpenAPI spec version: 1.0
   </ItemGroup>
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
-


### PR DESCRIPTION
BTA-15646 Update target framework version

Changes
-------

- Updates the target framework version to `v4.7.2` as `windows-2022` does not have `.NET` framework `v4.5` targeting pack installed by default (also this version is not maintained anymore).

<img width="2557" height="891" alt="Screenshot 2025-07-25 at 11 22 24" src="https://github.com/user-attachments/assets/d415ee51-801c-4a27-b39a-e8a79a9e64d5" />
