### PR TITLE
Install .NET Framework 4.5.2 Developer Pack for net45 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install msbuild and add to PATH
         uses: microsoft/setup-msbuild@v2
 
+      - name: Install .NET Framework 4.5 Developer Pack
+        run: choco install netfx-4.5.2-devpack -y --no-progress
+
       - name: Restore NuGet Packages
         run: nuget restore -SolutionDirectory ../..
         working-directory: src/TransferZero.Sdk


### PR DESCRIPTION
## Summary

Restores ability to build the SDK on `windows-latest` after Microsoft removed `v4.5` reference assemblies from the runner image (sometime between 2026-04 and now). Every release build has been failing with `MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found` — confirmed against the 2026-04-28 (1.37.4 cycle) and 2026-05-11 (AZAMIG-61 cycle) runs.

The `netfx-4.5.2-devpack` Chocolatey package includes a Multi-Targeting Pack with reference assemblies for `v4.0`/`v4.5`/`v4.5.1`/`v4.5.2`, so the existing `<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>` keeps working without a csproj retarget. No customer-facing API surface change.

## Background

This blocks AZAMIG-61 from reaching .NET customers — the spec staging deploy regenerated and pushed the 25 new `transfer_reason` keys to this repo's master, but the auto-trigger NuGet publish has been broken since at least 2026-04-28. NuGet `TransferZero.Sdk` is currently stuck at `1.37.1` (March 2024).

## Test plan

- [ ] Merge this PR → push triggers release.yml → Chocolatey step installs 4.5.2 dev pack (~30s) → MSBuild succeeds → `nuget pack` produces TransferZero.Sdk.1.37.5.nupkg → `nuget push` to nuget.org succeeds.
- [ ] Verify `https://www.nuget.org/packages/TransferZero.Sdk/1.37.5` returns 200.
- [ ] Confirm regenerated `Model/PayoutMethodTransferReasonEnum.cs` contains the 15 new enum entries (own_account, donations_gifts, family_support, mortgage_repayment, business_travel, personal_travel, management_consulting, advertising_market_research, cultural_recreational, salary_resident_abroad, salary_non_resident_in_sa, salary_foreign_contract_in_sa, commission_brokerage, investment_income, architectural_engineering).
