### PR TITLE
Use Microsoft.NETFramework.ReferenceAssemblies.net45 NuGet package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Install msbuild and add to PATH
         uses: microsoft/setup-msbuild@v2
 
-      - name: Install .NET Framework 4.5 Developer Pack
-        run: choco install netfx-4.5.2-devpack -y --no-progress
+      - name: Install .NET Framework 4.5 reference assemblies
+        run: |
+          nuget install Microsoft.NETFramework.ReferenceAssemblies.net45 -Version 1.0.3 -OutputDirectory C:\refasm -ExcludeVersion
+          "FrameworkPathOverride=C:\refasm\Microsoft.NETFramework.ReferenceAssemblies.net45\build\.NETFramework\v4.5\" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Restore NuGet Packages
         run: nuget restore -SolutionDirectory ../..
@@ -28,7 +30,7 @@ jobs:
 
       - name: Build and Pack
         run: |
-          msbuild /property:Configuration=Release
+          msbuild /property:Configuration=Release /property:FrameworkPathOverride=$env:FrameworkPathOverride
           nuget pack TransferZero.Sdk.csproj -properties Configuration=Release
         working-directory: src/TransferZero.Sdk
 


### PR DESCRIPTION
## Summary

Replaces the chocolatey `netfx-4.5.2-devpack` install (PR #14) with Microsoft's officially-maintained `Microsoft.NETFramework.ReferenceAssemblies.net45` NuGet package, which is the blessed CI path for compiling against legacy .NET Framework versions on hosted runners.

## Why #14 didn't work

PR #14 installed `netfx-4.5.2-devpack` via chocolatey. The package install logged success — even the chocolatey output says `The install of netfx-4.5.2-devpack was successful` — but the post-install MSBuild run on the very next commit still failed with `MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found`. Two clues from the chocolatey log:

> netfx-4.5.2-devpack v4.5.5165101.20180721 [Approved] - **Likely broken for FOSS users (due to download location changes)**

> Downloading netfx-4.5.2-devpack from `https://download.microsoft.com/download/4/3/B/.../NDP452-KB2901951-x86-x64-DevPack.exe`

The package wraps the original 2014 NDP452 installer. On the modern `windows-2022` runner with VS 2022 already installed, the legacy MSI's multi-targeting-pack registration is unreliable: the install completes, but the `v4.5` directory under `C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\` isn't populated.

## Fix

Use the NuGet package instead. It's a regular package — no installer state — and Microsoft pushes updates to it:

```yaml
- name: Install .NET Framework 4.5 reference assemblies
  run: |
    nuget install Microsoft.NETFramework.ReferenceAssemblies.net45 -Version 1.0.3 -OutputDirectory C:efasm -ExcludeVersion
    "FrameworkPathOverride=C:efasm\Microsoft.NETFramework.ReferenceAssemblies.net45uild\.NETFramework4.5" | Out-File -FilePath $env:GITHUB_ENV -Append
```

`FrameworkPathOverride` is then injected into the existing `msbuild` call. The csproj stays untouched.

## Test plan

- [ ] Merge → release.yml fires on push → step "Install .NET Framework 4.5 reference assemblies" succeeds → "Build and Pack" succeeds (MSB3644 gone) → "Publish to NuGet" pushes `TransferZero.Sdk.1.37.5.nupkg`.
- [ ] `curl -sI https://api.nuget.org/v3-flatcontainer/transferzero.sdk/1.37.5/transferzero.sdk.1.37.5.nupkg` returns 200.
- [ ] Spec PR bitpesa/bitpesa-api-specification#425 next pushes 1.37.6 → release.yml fires again → 1.37.6 lands on NuGet.

## Reverts

This replaces the dev pack step from #14 with a different mechanism — both PRs share the same goal. Leaving the .travis.yml situation (pre-existing Mono-on-focal failure) alone; admin-override merge remains the path for this PR too.
